### PR TITLE
chore(ci): make lockfile changes fail early

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install
+    - run: yarn install --frozen-lockfile
     - run: yarn test
     - run: yarn --cwd packages/app/ test:e2e:ci
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
Some missing constraints on the react types run into this late during the container image build. This should make it terminate the pipeline early if that is the case.